### PR TITLE
Consolidate CallInfo into CallData

### DIFF
--- a/lib/yruby/compile.rb
+++ b/lib/yruby/compile.rb
@@ -77,7 +77,7 @@ class YRuby
           compile_node(iseq, node.arguments)
           argc = node.arguments.arguments.size
         end
-        cd = CallData.new(ci: CallInfo.new(mid: node.name, argc:))
+        cd = CallData.new(mid: node.name, argc:)
         iseq.emit(YRuby::Insns::OptSendWithoutBlock, cd)
       else
         compile_node(iseq, node.receiver)

--- a/lib/yruby/core.rb
+++ b/lib/yruby/core.rb
@@ -15,6 +15,5 @@ class YRuby
   ControlFrame = Struct.new(:iseq, :pc, :sp, :ep, :type, :self_value, keyword_init: true)
   ExecutionContext = Struct.new(:stack, :stack_size, :cfp, :frames, keyword_init: true)
 
-  CallInfo = Struct.new(:mid, :argc, keyword_init: true)
-  CallData = Struct.new(:ci, keyword_init: true)
+  CallData = Struct.new(:mid, :argc, keyword_init: true)
 end

--- a/lib/yruby/insnhelper.rb
+++ b/lib/yruby/insnhelper.rb
@@ -96,15 +96,13 @@ class YRuby
     end
 
     def sendish(cd)
-      ci = cd.ci
-
-      argc = ci.argc
+      argc = cd.argc
       recv = topn(argc + 1)
 
       klass = recv.klass
-      method_iseq = klass.search_method(ci.mid)
+      method_iseq = klass.search_method(cd.mid)
 
-      raise "undefined method #{ci.mid}" if method_iseq.nil?
+      raise "undefined method #{cd.mid}" if method_iseq.nil?
 
       call_iseq_setup(recv, argc, method_iseq)
     end


### PR DESCRIPTION
Remove the separate CallInfo struct and merge its fields (mid, argc)
directly into CallData. Update all usages in compile.rb and insnhelper.rb
to access cd.mid and cd.argc directly instead of through cd.ci.

https://claude.ai/code/session_012QipTxKE29SPCc7pzJL8wx
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yuhi-sato/yruby/pull/8" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
