### PR TITLE
Move local variable nil initialization into push_frame

### DIFF
--- a/lib/yruby.rb
+++ b/lib/yruby.rb
@@ -35,7 +35,7 @@ class YRuby
   end
 
   def exec_core(iseq)
-    push_frame(iseq:, type: FRAME_TYPE_TOP, self_value: @top_self, sp: 0)
+    push_frame(iseq:, type: FRAME_TYPE_TOP, self_value: @top_self, sp: 0, local_size: iseq.local_table_size)
 
     catch(:finish) do
       loop do

--- a/lib/yruby/insnhelper.rb
+++ b/lib/yruby/insnhelper.rb
@@ -47,7 +47,10 @@ class YRuby
     end
 
     # Control Frame
-    def push_frame(iseq:, type: FRAME_TYPE_TOP, self_value: nil, sp:)
+    def push_frame(iseq:, type: FRAME_TYPE_TOP, self_value: nil, sp:, local_size:)
+      local_start = sp + iseq.local_table_size - local_size
+      local_size.times { |i| stack[local_start + i] = nil }
+
       sp = sp + iseq.local_table_size
       ep = sp - 1
 
@@ -86,13 +89,9 @@ class YRuby
         iseq: method_iseq,
         type: FRAME_TYPE_METHOD,
         self_value: recv,
-        sp: argv_index
+        sp: argv_index,
+        local_size: method_iseq.local_table_size - method_iseq.argc
       )
-
-      local_only_size = method_iseq.local_table_size - method_iseq.argc
-      local_only_size.times do |i|
-        env_write(-i, nil)
-      end
     end
 
     def sendish(cd)


### PR DESCRIPTION
Align with CRuby's vm_push_frame behavior where all local variable
slots are initialized to nil inside the frame setup function itself,
rather than after the fact in call_iseq_setup.

- push_frame now accepts local_size: and writes nil to non-parameter
  local slots before constructing the ControlFrame
- call_iseq_setup passes local_size = local_table_size - argc so that
  argument slots (already on the stack) are skipped
- exec_core passes local_size = local_table_size for the top-level
  frame where all locals need initialization

https://claude.ai/code/session_01GPs5c2UryBxaPWHVem3DXp
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/yuhi-sato/yruby/pull/9" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
